### PR TITLE
compatibility with sphinx pr #3668

### DIFF
--- a/sphinxcontrib/paverutils.py
+++ b/sphinxcontrib/paverutils.py
@@ -22,7 +22,7 @@ from paver.easy import *  # noqa
 import sphinx
 
 import textwrap
-
+from pkg_resources import parse_version
 
 @task
 def html(options):
@@ -190,11 +190,15 @@ def run_sphinx(options, *option_sets):
         '-D%s=%s' % (name, value)
         for (name, value) in getattr(options, 'config_args', {}).items()
     ]
-    sphinxopts = [
+    if parse_version(sphinx.__version__) < parse_version('1.7.0'):
+        sphinxopts = [""]
+    else:
+        sphinxopts = []
+    sphinxopts.extend([
         '-b', options.get('builder', 'html'),
         '-d', paths.doctrees,
         '-c', paths.confdir,
-    ]
+    ])
 
     if options.get('force_all', False):
         sphinxopts.append('-a')

--- a/sphinxcontrib/paverutils.py
+++ b/sphinxcontrib/paverutils.py
@@ -191,7 +191,6 @@ def run_sphinx(options, *option_sets):
         for (name, value) in getattr(options, 'config_args', {}).items()
     ]
     sphinxopts = [
-        '',
         '-b', options.get('builder', 'html'),
         '-d', paths.doctrees,
         '-c', paths.confdir,


### PR DESCRIPTION
This simple change restores compatibility with sphinx >= 1.7.0   However, it will break with older versions of sphinx.  This is due to the incompatible change made in  #sphinx-doc/sphinx/3668

Brad